### PR TITLE
Letters, Digits and Symbols counter, minor bugfixes and enchancments

### DIFF
--- a/modules/split-url.r
+++ b/modules/split-url.r
@@ -52,5 +52,3 @@ clean_split_url <- function(url_list) {
                                   "path", "query", "fragment")
   return(resulting_matrix)
 }
-
-

--- a/modules/url-ambiguity.r
+++ b/modules/url-ambiguity.r
@@ -48,6 +48,10 @@ letter_digit_letter <- function(string, n_digits_inside = 2) {
   let_dig_let_regex <- paste("[a-z][\\d\\!]{1,",
                              n_digits_inside,
                              "}[a-z]", sep = "")
+
+  colnames(string) <- paste(
+    "ldl_", colnames(string), sep = "_"
+  )
   symbol_count_helper(string, let_dig_let_regex)
 }
 
@@ -69,6 +73,10 @@ digit_letter_digit <- function(string, n_letters_inside = 2) {
   dig_let_dig_regex <- paste("\\d[a-z\\!]{1,",
                              n_letters_inside,
                              "}\\d", sep = "")
+
+  colnames(string) <- paste(
+    "dld_", colnames(string), sep = "_"
+  )
   symbol_count_helper(string, dig_let_dig_regex)
 }
 
@@ -95,5 +103,9 @@ combined_url_ambiguity <- function(string, n_symbols_inside = 2) {
                            "2}[a-z]|\\d[a-z\\!]{1,",
                            n_symbols_inside,
                            "2}\\d", sep = "")
+
+  colnames(string) <- paste(
+    "xyx_", colnames(string), sep = "_"
+  )
   symbol_count_helper(string, ambiguity_regex)
 }

--- a/modules/url-ambiguity.r
+++ b/modules/url-ambiguity.r
@@ -1,4 +1,4 @@
-url_ambiguity_helper <- function(string, appropriate_regex) {
+symbol_count_helper <- function(string, appropriate_regex) {
   # ---------------------------------------------------------
   # Counts number of "appropriate_regex" sequences in the "string"
   #
@@ -48,7 +48,7 @@ letter_digit_letter <- function(string, n_digits_inside = 2) {
   let_dig_let_regex <- paste("[a-z][\\d\\!]{1,",
                              n_digits_inside,
                              "}[a-z]", sep = "")
-  url_ambiguity_helper(string, let_dig_let_regex)
+  symbol_count_helper(string, let_dig_let_regex)
 }
 
 
@@ -69,7 +69,7 @@ digit_letter_digit <- function(string, n_letters_inside = 2) {
   dig_let_dig_regex <- paste("\\d[a-z\\!]{1,",
                              n_letters_inside,
                              "}\\d", sep = "")
-  url_ambiguity_helper(string, dig_let_dig_regex)
+  symbol_count_helper(string, dig_let_dig_regex)
 }
 
 
@@ -95,5 +95,5 @@ combined_url_ambiguity <- function(string, n_symbols_inside = 2) {
                            "2}[a-z]|\\d[a-z\\!]{1,",
                            n_symbols_inside,
                            "2}\\d", sep = "")
-  url_ambiguity_helper(string, ambiguity_regex)
+  symbol_count_helper(string, ambiguity_regex)
 }

--- a/modules/url-lengths.r
+++ b/modules/url-lengths.r
@@ -53,5 +53,3 @@ url_lengths <- function(devided_url) {
   # Joined matrices
   return(cbind(partial_lengths, ratios_matrix))
 }
-
-

--- a/modules/url-special-symbol-count.r
+++ b/modules/url-special-symbol-count.r
@@ -17,7 +17,7 @@ lett_dig_symb_count <- function(string) {
   
   letters_regex <- "[a-zA-Z]"
   digits_regex <- "[\\d]"
-  symbols_regex <- "[^\\dA-Za-z\\s]"
+  symbols_regex <- "[[:punct:]]"
   lett_count <- as.matrix(symbol_count_helper(string, letters_regex))
   dig_count <- as.matrix(symbol_count_helper(string, digits_regex))
   symb_count <- as.matrix(symbol_count_helper(string, symbols_regex))

--- a/modules/url-special-symbol-count.r
+++ b/modules/url-special-symbol-count.r
@@ -1,0 +1,37 @@
+# Required module:
+source("url-ambiguity.r")
+
+
+lett_dig_symb_count <- function(string) {
+  # -------------------------------------
+  # Counts letters, digits and symbols 
+  # separately in the string
+  #
+  # Arguments:
+  #   string            A character or a character matrix. 
+  #
+  # Value:
+  #   matrix which has 3 times more columns then the
+  #   input "string" variable
+  # ------
+  
+  letters_regex <- "[a-zA-Z]"
+  digits_regex <- "[\\d]"
+  symbols_regex <- "[^\\dA-Za-z\\s]"
+  lett_count <- as.matrix(symbol_count_helper(string, letters_regex))
+  dig_count <- as.matrix(symbol_count_helper(string, digits_regex))
+  symb_count <- as.matrix(symbol_count_helper(string, symbols_regex))
+  
+  # Adding prefixes to the column names 
+  colnames(lett_count) <- paste(
+    "lett", colnames(lett_count), sep = "_"
+    )
+  colnames(dig_count) <- paste(
+    "dig", colnames(dig_count), sep = "_"
+  )
+  colnames(symb_count) <- paste(
+    "symb", colnames(symb_count), sep = "_"
+  )
+  
+  cbind(lett_count, dig_count, symb_count)
+}

--- a/project_diary_Vitalii.md
+++ b/project_diary_Vitalii.md
@@ -13,4 +13,6 @@
  - Dodaliśmy trzy funkcji do obliczania ilości wystąpień ciągów postaci: litera między dwiema cyframi (np. 9l1) lub cyfra między dwiema literami (np. examp1e). *(`modules/url-ambiguity.r`)*  
  Takie cechy mogą pomóc wykryć, czy adres URL próbuje oszukać użytkownika, czy nie.
 
- 
+ ---
+
+ - Została zaimplementowana funkcja dla liczenia oddzielnie ilości liter, cyfr i znaków interpunkcyjnych (funkcja `lett_dig_symb_count()` w pliku *`modules/url-special-symbol-count.r`*)


### PR DESCRIPTION
 - Column names prefixes were added in modules/url-ambiguity.r outputs
 - modules/url-special-symbol-count.r now contains function lett_dig_symb_count() function which counts letters, digits and symbols separately
 - url_ambiguity_helper() was renamed to symbol_count_helper() in the modules/url-ambiguity.r file